### PR TITLE
Use memo

### DIFF
--- a/src/components/about-hero.js
+++ b/src/components/about-hero.js
@@ -5,6 +5,12 @@ import { Container, Section, Text, SuperHeading } from "./ui"
 import * as styles from "./about-hero.css"
 
 export default function AboutHero(props) {
+  const [fakeValue, setFakeValue] = React.useState(false)
+  React.useEffect(() => {
+    console.log("about hero has mounted! ", fakeValue)
+    setFakeValue(true)
+  }, [])
+
   return (
     <Section>
       <Container>

--- a/src/components/sections.js
+++ b/src/components/sections.js
@@ -1,12 +1,16 @@
-export { default as HomepageHero } from "./hero"
-export { default as HomepageFeatureList } from "./feature-list"
-export { default as HomepageLogoList } from "./logo-list"
-export { default as HomepageBenefitList } from "./benefit-list"
-export { default as HomepageTestimonialList } from "./testimonial-list"
-export { default as HomepageStatList } from "./stat-list"
-export { default as HomepageCta } from "./cta"
-export { default as HomepageProductList } from "./product-list"
-export { default as AboutHero } from "./about-hero"
-export { default as AboutStatList } from "./about-stat-list"
-export { default as AboutLeadership } from "./about-leadership"
-export { default as AboutLogoList } from "./about-logo-list"
+import React from "react"
+
+export const HomepageHero = React.lazy(() => import("./hero"))
+export const HomepageFeatureList = React.lazy(() => import("./feature-list"))
+export const HomepageLogoList = React.lazy(() => import("./logo-list"))
+export const HomepageBenefitList = React.lazy(() => import("./benefit-list"))
+export const HomepageTestimonialList = React.lazy(() =>
+  import("./testimonial-list")
+)
+export const HomepageStatList = React.lazy(() => import("./stat-list"))
+export const HomepageCta = React.lazy(() => import("./cta"))
+export const HomepageProductList = React.lazy(() => import("./product-list"))
+export const AboutHero = React.lazy(() => import("./about-hero"))
+export const AboutStatList = React.lazy(() => import("./about-stat-list"))
+export const AboutLeadership = React.lazy(() => import("./about-leadership"))
+export const AboutLogoList = React.lazy(() => import("./about-logo-list"))

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,6 +5,17 @@ import * as sections from "../components/sections"
 import Fallback from "../components/fallback"
 import SEOHead from "../components/head"
 
+const Block = React.memo(({ block }) => {
+  const { id, blocktype, ...componentProps } = block
+  const Component = sections[blocktype] || Fallback
+  console.log("rendering block: ", blocktype)
+  return (
+    <React.Suspense fallback={`Loading... ${blocktype}`}>
+      <Component key={id} {...componentProps} />
+    </React.Suspense>
+  )
+})
+
 export default function Homepage(props) {
   const [fakeValue, setFakeValue] = React.useState(false)
   React.useEffect(() => {
@@ -15,15 +26,9 @@ export default function Homepage(props) {
 
   return (
     <Layout>
-      {homepage.blocks.map((block) => {
-        const { id, blocktype, ...componentProps } = block
-        const Component = sections[blocktype] || Fallback
-        return (
-          <React.Suspense fallback={null}>
-            <Component key={id} {...componentProps} />
-          </React.Suspense>
-        )
-      })}
+      {homepage.blocks.map((block) => (
+        <Block block={block} />
+      ))}
     </Layout>
   )
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,6 +6,11 @@ import Fallback from "../components/fallback"
 import SEOHead from "../components/head"
 
 export default function Homepage(props) {
+  const [fakeValue, setFakeValue] = React.useState(false)
+  React.useEffect(() => {
+    console.log("hey, there ", fakeValue)
+    setFakeValue(true)
+  }, [])
   const { homepage } = props.data
 
   return (
@@ -13,7 +18,11 @@ export default function Homepage(props) {
       {homepage.blocks.map((block) => {
         const { id, blocktype, ...componentProps } = block
         const Component = sections[blocktype] || Fallback
-        return <Component key={id} {...componentProps} />
+        return (
+          <React.Suspense fallback={null}>
+            <Component key={id} {...componentProps} />
+          </React.Suspense>
+        )
       })}
     </Layout>
   )


### PR DESCRIPTION
## Purpose

This PR demonstrates how to utilize memoization in React to stop undesirable utilization of a fallback component for a lazy loaded component upon hydration in the browser.

In short, we are triggering a change in the DOM in the browser compared to what was built on the server during the Gatsby build with a dummy `useEffect` and `setState` call. You can also see triggered change in isolation in #1.

Since the state change doesn't actually affect how we render the contents of this page, as it's not a prop passed to any of the lazy loaded components, we utilize `Memo`'d versions of those components so that React knows not to bother re-rendering them when it detects the DOM difference and goes to reconcile.


You can see this in action by clicking the deploy preview link here: [Deploy preview](https://gatsbystartercontentfulho07016-usememo.gatsbyjs.io/)

Or watching the screen capture of this with a throttled network connection to slow things down and show there's no utilization of fallback components:
https://user-images.githubusercontent.com/1790506/225989666-55c6621e-7fc9-4da4-9079-1a89a1e10e4f.mov

